### PR TITLE
bug-fix: fixed the arxiv status_code error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__
 *.pyc
 local-test.yaml
 local-test.yml
+.venv/

--- a/tasks.py
+++ b/tasks.py
@@ -40,14 +40,12 @@ def sort_ref(ref_dict):
                   )
     if ref_dict['reftype'] == 'arxiv':
         url = "http://arxiv.org/abs/"+ref_dict['ref']
-        url = sanitize_url(url)
         result['arxiv'].append(url)
     elif ref_dict['reftype'] == 'doi':
         url = "http://doi.org/"+ref_dict['ref']
-        url = sanitize_url(url)
         result['doi'].append(url)
-
-    url = sanitize_url(ref_dict['ref'])
+    else:
+        url = ref_dict['ref']
     try:
         stat = str(get_status_code(url))
     except Exception as ex:


### PR DESCRIPTION
### Summary:
This PR Addresses the Issue: https://github.com/rottingresearch/rottingresearch/issues/145.

### Reflections:
1. The URL we get from Linkrot will get formatted twice, which skips the URL encoded format for the `arxiv` and `doi` ref types. So, I added another case to fix it.
2. I removed `sanitize_url` on task url's because we are doing redundant calls(over computation) here. It will get sanitized in the `get_status_code` function.

### Screenshot:
![Screenshot 2023-11-17 125420](https://github.com/rottingresearch/rottingresearch/assets/21984731/8435ef25-e310-4f10-9431-d0b904f8c77f)

