### PR TITLE
#189 - Local Setup Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,35 @@ Check out our website at [rottingresearch.org](https://rottingresearch.org/).
 The status of our services can be observed at [status.rottingresearch.org/status/rr](https://status.rottingresearch.org/status/rr).
 
 # Installation  
-### Linux/Mac  
+## Requirements
+- Python3 (3.10+)
+- Pip3
+- Redis
+
+## Docker Instructions  
+### Local Development  
+To setup the application for local developer:  
+- Set the `APP_SECRET_KEY`  
+- Run the docker container using `docker-compose up --build`. You can use the
+`-d` flag to run the containers in 'detached' mode.  
+- Open [127.0.0.1:8080](http://127.0.0.1:8080) on your browser.  
+
+As docker volume is used any changes made are reflected immediately. To view 
+the container logs you can use `docker logs -f rottingresearch`. The `-f` flag 
+is used for following the logs.
+
+### Building Image  
+- Build the docker image `docker build --tag rottingresearch .`
+- Run image `docker run -d -p 8080:8080 rottingresearch`
+
+
+## Linux/Mac  
 - Clone Repository: `git clone https://github.com/rottingresearch/rottingresearch`  
 - Change directory to `rottingresearch` - `cd rottingresearch`
 - Run `source setup.sh` - the script will automatically install the packages 
 and setup the environment variables
 
-### Windows  
+## Windows  
 - Clone Repository: `git clone https://github.com/rottingresearch/rottingresearch`   
 - Change directory to `rottingresearch` - `cd rottingresearch`  
 - Install Python Packages: `pip3 install -r requirements.txt`  
@@ -35,21 +57,6 @@ and setup the environment variables
 - Run Celery worker `celery -A app:celery_app worker -B`  
 - Open [127.0.0.1:8080](http://127.0.0.1:8080) on your browser.  
 
-# Docker Instructions  
-## Local Development  
-To setup the application for local developer:  
-- Set the `APP_SECRET_KEY`  
-- Run the docker container using `docker-compose up --build`. You can use the
-`-d` flag to run the containers in 'detached' mode.  
-- Open [127.0.0.1:8080](http://127.0.0.1:8080) on your browser.  
-
-As docker volume is used any changes made are reflected immediately. To view 
-the container logs you can use `docker logs -f rottingresearch`. The `-f` flag 
-is used for following the logs.
-
-## Building Image  
-- Build the docker image `docker build --tag rottingresearch .`
-- Run image `docker run -d -p 8080:8080 rottingresearch`
 
 # Code of Conduct  
 For our code of conduct, please visit our [Code of Conduct page](https://github.com/rottingresearch/rottingresearch/blob/main/code_of_conduct.md).

--- a/README.md
+++ b/README.md
@@ -22,14 +22,13 @@ The status of our services can be observed at [status.rottingresearch.org/status
 - Redis
 
 ## Docker Instructions  
-### Local Development  
-To setup the application for local developer:  
-- Set the `APP_SECRET_KEY`  
+### Local Development    
+- Set the `APP_SECRET_KEY="RANDOM_SECRET_KEY"`  
 - Run the docker container using `docker-compose up --build`. You can use the
 `-d` flag to run the containers in 'detached' mode.  
-- Open [127.0.0.1:8080](http://127.0.0.1:8080) on your browser.  
+- Open [127.0.0.1:8080](http://127.0.0.1:8080) in your browser.  
 
-As docker volume is used any changes made are reflected immediately. To view 
+As docker volume is used, any changes made are reflected immediately. To view 
 the container logs you can use `docker logs -f rottingresearch`. The `-f` flag 
 is used for following the logs.
 

--- a/README.md
+++ b/README.md
@@ -2,98 +2,57 @@
 
 # Introduction
 
-A project devoted to helping academics and researchers provide robust citations and mitigate link rot.
+A project devoted to helping academics and researchers provide robust citations and mitigate link rot. Visit
+[rottingresearch.org](https://rottingresearch.org/) to see it in action.
+
 
 # Mission
-
 Link rot is an established phenomenon that affects everyone who uses the internet. Researchers looking at individual subjects have recently addressed the extent of link rot’s influence on scholarly publications. One recent study found that 36% of all links in research articles were broken. 37% of DOIs, once seen as a tool to prevent link rot, were broken (Miller, 2022).
 
 Rotting Research allows academics and researchers to upload their work and check the reliability of their citations. It extracts all of the links from the document and then checks to see if the link is accessible to the public.
 
-Check out our website at https://rottingresearch.org.
+Check out our website at [rottingresearch.org](https://rottingresearch.org/).
 
-The status of our services can be observed at https://status.rottingresearch.org/status/rr.
+The status of our services can be observed at [status.rottingresearch.org/status/rr](https://status.rottingresearch.org/status/rr).
 
-# Installation
+# Installation  
+### Linux/Mac  
+- Clone Repository: `git clone https://github.com/rottingresearch/rottingresearch`  
+- Change directory to `rottingresearch` - `cd rottingresearch`
+- Run `source setup.sh` - the script will automatically install the packages 
+and setup the environment variables
 
-- Local development works best with Python 3.10+ versions.
+### Windows  
+- Clone Repository: `git clone https://github.com/rottingresearch/rottingresearch`   
+- Change directory to `rottingresearch` - `cd rottingresearch`  
+- Install Python Packages: `pip3 install -r requirements.txt`  
+- Edit `app.py` and set `app.config['UPLOAD_FOLDER']` to a valid temporary folder.  
+- Set `APP_SECRET_KEY` environment variable - `setx APP_SECRET_KEY "random"`  
+- Set `ENV` running environment variable `setx ENV "DEV"` 
+- Run redis `redis-server`  
+- Set REDIS_URL environment `setx REDIS_URL "redis://localhost:6379"`  
+- Run app `python3 app.py`  
+- Run Celery worker `celery -A app:celery_app worker -B`  
+- Open [127.0.0.1:8080](http://127.0.0.1:8080) on your browser.  
 
-- Make sure you have Python and the latest version of pip installed.
+# Docker Instructions  
+## Local Development  
+To setup the application for local developer:  
+- Set the `APP_SECRET_KEY`  
+- Run the docker container using `docker-compose up --build`. You can use the
+`-d` flag to run the containers in 'detached' mode.  
+- Open [127.0.0.1:8080](http://127.0.0.1:8080) on your browser.  
 
-  `python3 -m pip install --upgrade pip`
+As docker volume is used any changes made are reflected immediately. To view 
+the container logs you can use `docker logs -f rottingresearch`. The `-f` flag 
+is used for following the logs.
 
-- Download Project
-
-  `git clone https://github.com/rottingresearch/rottingresearch`
-
-- Navigate to the root folder.
-
-- Install Requirements
-
-  `pip3 install -r requirements.txt`
-
-- If using Windows, open app.py and set app.config['UPLOAD_FOLDER'] to a valid temporary folder.
-- Set APP_SECRET_KEY environment variable before running the python script.
-
-  Linux: `export APP_SECRET_KEY="random"`
-
-  Windows: `setx APP_SECRET_KEY "random"`
-
-- Set ENV environment variable
-
-  Linux: `export ENV="DEV"`
-
-  Windows: `setx ENV "DEV"`
-
-- Run redis
-
-  `redis-server`
-
-- Set REDIS_URL environment variable before running the python script
-
-  Linux: `export REDIS_URL="redis://localhost:6379"`
-
-  Windows: `setx REDIS_URL "redis://localhost:6379"`
-
-- Run Flask App
-
-  `python3 app.py`
-
-- Run Celery worker
-
-  `celery -A app:celery_app worker -B`
-
-- Open 127.0.0.1:8080 on your browser.
-
-# Docker Instructions
-
-## Local Development
-
-Docker-Compose is being used for local development mainly due to its ease of use and development.
-
-- Set the `APP_SECRET_KEY`
-- `docker-compose up --build -d` to run the container in detached mode.
-
-The application is running on port `8080`. Docker volume is used so whenever changes are made they are reflected immediately. To view the container logs you can use `docker logs -f rottingresearch`. The `f` flag is used for following the logs.
-
-## Building Image
-
-- Clone repo `git clone https://github.com/rottingresearch/rottingresearch.git`
+## Building Image  
 - Build the docker image `docker build --tag rottingresearch .`
 - Run image `docker run -d -p 8080:8080 rottingresearch`
 
-# Features
-
-- Coming Soon
-
-# Demo Site
-
-The App is hosted at [https://rottingresearch.org/](https://rottingresearch.org/) during development.
-
-# Code of Conduct
-
+# Code of Conduct  
 For our code of conduct, please visit our [Code of Conduct page](https://github.com/rottingresearch/rottingresearch/blob/main/code_of_conduct.md).
 
-# License
-
+# License  
 This program is licensed with a [GPLv3 License](https://github.com/rottingresearch/rottingresearch/blob/main/LICENSE).

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Check if python3 is installed
+if ! command -v python3 &> /dev/null; 
+then
+    echo "python3 is not installed. Please install python3 and try again.";
+    exit 1;
+fi
+
+
+# Check if pip is installed (pipx, brew, etc.)
+if ! command -v pip3 &> /dev/null; 
+then
+    echo "pip3 is not installed. Please install pip3 and try again.";
+    exit 1;
+fi
+
+
+# Check if redis-server is installed (if not exit)
+if ! command -v redis-server &> /dev/null; 
+then
+    echo "redis-server is not installed. Please install redis-server and try agian.";
+    exit 1;
+fi
+
+
+# Install packages (pip3 install -r requirements.txt)
+echo "Installing packages";
+if ! pip3 install -r requirements.txt ; then
+    echo "Error install packages. Likely there is another package manager installed";
+    echo "which is preventing pip3 from installing the packages. If you want to continue";
+    echo "installing packages run 'pip3 install -r requirements.txt --break-system-packages'.";
+    exit 1;
+else
+    echo "Packages are successfully installed";
+fi
+
+# Setting environment variables
+RANDOM_KEY=""
+if command -v openssl &> /dev/null;
+then 
+    RANDOM_KEY=$(openssl rand -base64 12 | tr -dc A-Za-z0-9 | head -c 16);
+else
+    RANDOM_KEY="%R4nD0M_K3y&";
+fi
+
+export APP_SECRET_KEY=$RANDOM_KEY;
+export ENV="DEV";
+export REDIS_URL="redis://localhost:6379";
+
+
+# EOF


### PR DESCRIPTION
## Description 
Created local setup script(`setup.sh`) to automatically install packages and to setup the environment variables. Update the readme to reflect the changes.

## What does the script not do?
The setup script does not install `python3`,`pip3` or `redis-server`. The user must install these themselves prior to running the `setup.sh` script.


## What does the script do?
Installs python packages & set the environment variables.

## Testing
- Script was tested locally on a Mac
- Script was tested on Ubuntu docker container

### Tests
- Script fails if `python3` is not installed. (Ubuntu, mac)
- Script fails if `pip3` in not installed. (Ubuntu, mac)
- Script fails if `pip3` fails to install `requirements.txt`. (Ubuntu, mac)
- Script fails if `redis-server` is not installed. (Ubuntu, mac)
- Script fails if `redis-server` is not running. Ask user to run `redis-server`

- Script sets `APP_SECRET_KEY` to `%R4nD0M_K3y&` if `openssl` is not installed (Ubuntu)
- Script sets `APP_SECRET_KEY` to a randomly generated value using `openssl` (Ubuntu, mac)
- Script successfully sets the environment variables (Ubuntu,  mac)


