### PR TITLE
Potential fix for code scanning alert no. 21: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,5 +1,7 @@
 name: Lighthouse CI
 on: push
+permissions:
+  contents: read
 jobs:
   lighthouse:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/rottingresearch/rottingresearch/security/code-scanning/21](https://github.com/rottingresearch/rottingresearch/security/code-scanning/21)

To fix the issue, add a `permissions` block to the workflow. Since the workflow only requires read access to repository contents, the permissions should be set to `contents: read`. This ensures that the `GITHUB_TOKEN` has the minimum required privileges, reducing the risk of unintended write operations.

The `permissions` block should be added at the root level of the workflow, so it applies to all jobs. This change does not affect the functionality of the workflow but improves its security posture.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
