### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/browser-stack.yml
+++ b/.github/workflows/browser-stack.yml
@@ -1,4 +1,6 @@
 name: BrowserStack
+permissions:
+  contents: read
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/rottingresearch/rottingresearch/security/code-scanning/19](https://github.com/rottingresearch/rottingresearch/security/code-scanning/19)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function. Based on the workflow's tasks, it appears that only `contents: read` is necessary, as the workflow interacts with external services (BrowserStack) and does not modify repository contents or create pull requests.

The `permissions` block will be added after the `name` field and before the `on` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
