### PR TITLE
Potential fix for code scanning alert no. 27: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Test Suite
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, develop ]


### PR DESCRIPTION
Potential fix for [https://github.com/rottingresearch/rottingresearch/security/code-scanning/27](https://github.com/rottingresearch/rottingresearch/security/code-scanning/27)

In general, the fix is to define an explicit `permissions:` block that grants only the minimal scopes the workflow actually needs. For a CI workflow that only checks out code, caches dependencies, runs tests, sends coverage to Codecov, and uploads artifacts, read access to repository contents is sufficient; no write permissions or special scopes (e.g., `pull-requests`, `issues`) are required.

The best, non-functional-impact fix here is to add a `permissions:` block at the workflow root (top level, alongside `name:` and `on:`) so that it applies uniformly to all jobs, including `test`. Based on the shown steps, the only required scope is `contents: read`, which allows `actions/checkout` to read the repo. Caching with `actions/cache`, uploading artifacts with `actions/upload-artifact`, and uploading coverage to Codecov do not require write access to the repository via `GITHUB_TOKEN`.

Concretely, in `.github/workflows/test.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name: Test Suite` line and the `on:` section (lines 1 and 3 in the provided snippet). No additional imports or external dependencies are required; this is purely a YAML configuration change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
