### PR TITLE
Potential fix for code scanning alert no. 28: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -1,5 +1,8 @@
 name: Qodana
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/rottingresearch/rottingresearch/security/code-scanning/28](https://github.com/rottingresearch/rottingresearch/security/code-scanning/28)

In general, the fix is to explicitly declare a `permissions` block for the workflow (or at least for the `qodana` job) that grants only the minimum required access to the `GITHUB_TOKEN`. For a workflow that only checks out the repository and runs a static analysis action, `contents: read` is typically sufficient.

The best minimal change here is to add a root-level `permissions` block that applies to all jobs, directly under the `name` field and before `on:` in `.github/workflows/qodana.yml`. This will ensure that `GITHUB_TOKEN` is restricted to read-only repository contents across the workflow, without altering any existing behavior of the Qodana scan. No extra imports or other files are needed—only a small YAML edit in this workflow file.

Concretely:
- Edit `.github/workflows/qodana.yml`.
- Insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: Qodana`) and before the `on:` block (current line 3). This satisfies CodeQL’s recommendation and follows least-privilege principles.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
